### PR TITLE
Fix missing dependency for screen-navigation WebRTC example

### DIFF
--- a/examples/screen-navigation-webrtc/server/requirements.txt
+++ b/examples/screen-navigation-webrtc/server/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv
 fastapi[all]
 uvicorn
 pipecat-ai[deepgram,silero,webrtc]
+pipecat-ai-small-webrtc-prebuilt


### PR DESCRIPTION
## Summary
- update `requirements.txt` for the screen-navigation demo to include the `pipecat-ai-small-webrtc-prebuilt` package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_684c99a0e904832a9dc34fa339d4fceb