### PR TITLE
Add Docker flow for screen navigation example

### DIFF
--- a/examples/screen-navigation-webrtc/Dockerfile
+++ b/examples/screen-navigation-webrtc/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-bullseye
+
+WORKDIR /app
+
+COPY server/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server ./server
+
+EXPOSE 7860
+
+CMD ["python", "server/server.py"]

--- a/examples/screen-navigation-webrtc/README.md
+++ b/examples/screen-navigation-webrtc/README.md
@@ -39,3 +39,10 @@ transcript of each utterance and any detected commands.
 - Python 3.10+
 - A modern browser with WebRTC support
 - A Deepgram API key
+
+## Build and test the Docker image
+
+```bash
+docker build -t screen-navigation-webrtc .
+docker run --env-file server/.env -p 7860:7860 screen-navigation-webrtc
+```


### PR DESCRIPTION
## Summary
- add a Dockerfile for `examples/screen-navigation-webrtc`
- document how to build and run the image

## Testing
- `pre-commit run --files examples/screen-navigation-webrtc/Dockerfile examples/screen-navigation-webrtc/README.md` *(fails: command not found)*
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684ca5b1c194832abdea069ce7a2d584