### PR TITLE
Update screen navigation Dockerfile

### DIFF
--- a/examples/screen-navigation-webrtc/Dockerfile
+++ b/examples/screen-navigation-webrtc/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.10-bullseye
 
+RUN apt-get update && \
+    apt-get install -y libgl1 libglib2.0-0 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY server/requirements.txt ./requirements.txt


### PR DESCRIPTION
## Summary
- add `apt-get` step to install `libgl1` and `libglib2.0-0` in WebRTC example Dockerfile
- clean apt caches to keep image small

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc40d402c832aac15650f886081fa