### PR TITLE
Remove prebuilt UI from WebRTC example

### DIFF
--- a/examples/screen-navigation-webrtc/README.md
+++ b/examples/screen-navigation-webrtc/README.md
@@ -28,16 +28,16 @@ service (Deepgram in this demo) and simple patterns are matched to emit commands
    python server/server.py --host 0.0.0.0
    ```
 
-### 2. Connect from a browser
+### 2. Connect with your own WebRTC client
 
-Open `http://localhost:7860` (replace `localhost` with your host IP if running remotely) and allow microphone access. Speak commands like
-"scroll down" or "click search box". The server sends back JSON messages with the
-transcript of each utterance and any detected commands.
+Use a custom WebRTC client to exchange SDP with the server's `/api/offer` endpoint.
+Once connected, audio will stream to the server and JSON messages containing
+transcripts and detected commands are sent back over the data channel.
 
 ## Requirements
 
 - Python 3.10+
-- A modern browser with WebRTC support
+- A WebRTC-capable client (browser or custom application)
 - A Deepgram API key
 
 ## Build and test the Docker image

--- a/examples/screen-navigation-webrtc/server/requirements.txt
+++ b/examples/screen-navigation-webrtc/server/requirements.txt
@@ -2,4 +2,3 @@ python-dotenv
 fastapi[all]
 uvicorn
 pipecat-ai[deepgram,silero,webrtc]
-pipecat-ai-small-webrtc-prebuilt

--- a/examples/screen-navigation-webrtc/server/server.py
+++ b/examples/screen-navigation-webrtc/server/server.py
@@ -8,9 +8,7 @@ import uvicorn
 from bot import run_bot
 from dotenv import load_dotenv
 from fastapi import BackgroundTasks, FastAPI
-from fastapi.responses import RedirectResponse
 from loguru import logger
-from pipecat_ai_small_webrtc_prebuilt.frontend import SmallWebRTCPrebuiltUI
 
 from pipecat.transports.network.webrtc_connection import IceServer, SmallWebRTCConnection
 
@@ -21,13 +19,6 @@ app = FastAPI()
 pcs_map: Dict[str, SmallWebRTCConnection] = {}
 
 ice_servers = [IceServer(urls="stun:stun.l.google.com:19302")]
-
-app.mount("/prebuilt", SmallWebRTCPrebuiltUI)
-
-
-@app.get("/", include_in_schema=False)
-async def root_redirect():
-    return RedirectResponse(url="/prebuilt/")
 
 
 @app.post("/api/offer")
@@ -67,8 +58,12 @@ async def lifespan(app: FastAPI):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Screen navigation demo")
-    parser.add_argument("--host", default="localhost", help="Host for HTTP server (default: localhost)")
-    parser.add_argument("--port", type=int, default=7860, help="Port for HTTP server (default: 7860)")
+    parser.add_argument(
+        "--host", default="localhost", help="Host for HTTP server (default: localhost)"
+    )
+    parser.add_argument(
+        "--port", type=int, default=7860, help="Port for HTTP server (default: 7860)"
+    )
     parser.add_argument("--verbose", "-v", action="count")
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- remove the SmallWebRTCPrebuilt UI from the screen-navigation WebRTC demo server
- clean up requirements
- update README instructions for using a custom WebRTC client

## Testing
- `ruff format examples/screen-navigation-webrtc/server/server.py`
- `ruff check examples/screen-navigation-webrtc/server/server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cec37cfb8832a89572647cce31fb6