### PR TITLE
Add example-local JSON sentence aggregator

### DIFF
--- a/examples/screen-navigation-webrtc/server/bot.py
+++ b/examples/screen-navigation-webrtc/server/bot.py
@@ -15,7 +15,7 @@ from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.transcript_processor import TranscriptProcessor
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
-from pipecat.processors.aggregators.sentence import SentenceAggregator
+from json_sentence_aggregator import JSONSentenceAggregator
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.openai.llm import OpenAILLMService
@@ -95,7 +95,7 @@ async def run_bot(webrtc_connection):
     context = OpenAILLMContext([{"role": "system", "content": SYSTEM_PROMPT}])
     context_aggregator = llm.create_context_aggregator(context)
 
-    sentence_agg = SentenceAggregator()
+    sentence_agg = JSONSentenceAggregator()
     llm_handler = LLMOutputHandler(transport)
 
     pipeline = Pipeline(

--- a/examples/screen-navigation-webrtc/server/json_sentence_aggregator.py
+++ b/examples/screen-navigation-webrtc/server/json_sentence_aggregator.py
@@ -1,0 +1,49 @@
+import json
+from pipecat.frames.frames import EndFrame, Frame, InterimTranscriptionFrame, TextFrame
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.utils.string import match_endofsentence
+
+
+class JSONSentenceAggregator(FrameProcessor):
+    """Aggregate text until a complete sentence or JSON object is received."""
+
+    def __init__(self):
+        super().__init__()
+        self._aggregation = ""
+
+    def _is_complete_json(self, text: str) -> bool:
+        text = text.strip()
+        if not text or text[0] not in "{[":
+            return False
+        try:
+            _, idx = json.JSONDecoder().raw_decode(text)
+            return idx == len(text)
+        except json.JSONDecodeError:
+            return False
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, InterimTranscriptionFrame):
+            return
+
+        if isinstance(frame, TextFrame):
+            self._aggregation += frame.text
+            while True:
+                if self._is_complete_json(self._aggregation):
+                    await self.push_frame(TextFrame(self._aggregation.strip()))
+                    self._aggregation = ""
+                else:
+                    eos = match_endofsentence(self._aggregation)
+                    if eos:
+                        await self.push_frame(TextFrame(self._aggregation[:eos]))
+                        self._aggregation = self._aggregation[eos:]
+                        continue
+                break
+        elif isinstance(frame, EndFrame):
+            if self._aggregation:
+                await self.push_frame(TextFrame(self._aggregation))
+                self._aggregation = ""
+            await self.push_frame(frame)
+        else:
+            await self.push_frame(frame, direction)

--- a/examples/screen-navigation-webrtc/tests/test_json_sentence_aggregator.py
+++ b/examples/screen-navigation-webrtc/tests/test_json_sentence_aggregator.py
@@ -1,0 +1,53 @@
+import unittest
+
+from pipecat.frames.frames import TextFrame
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "server")))
+from json_sentence_aggregator import JSONSentenceAggregator  # noqa: E402
+from pipecat.tests.utils import run_test
+
+
+class TestJSONSentenceAggregator(unittest.IsolatedAsyncioTestCase):
+    async def test_json_detection(self):
+        aggregator = JSONSentenceAggregator()
+
+        frames_to_send = [
+            TextFrame("{"),
+            TextFrame('"kind": "need",'),
+            TextFrame(' "id": "123"'),
+            TextFrame("}"),
+        ]
+
+        expected_down_frames = [TextFrame]
+
+        (received_down, _) = await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+
+        assert received_down[0].text == '{"kind": "need", "id": "123"}'
+
+    async def test_sentence_and_json(self):
+        aggregator = JSONSentenceAggregator()
+
+        frames_to_send = [
+            TextFrame("Hello world."),
+            TextFrame(" {"),
+            TextFrame('"kind": "need"'),
+            TextFrame(', "id": "1"'),
+            TextFrame("}"),
+        ]
+
+        expected_down_frames = [TextFrame, TextFrame]
+
+        (received_down, _) = await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+
+        assert received_down[0].text == "Hello world."
+        assert received_down[1].text == '{"kind": "need", "id": "1"}'

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -16,6 +16,7 @@ from pipecat.frames.frames import (
 )
 from pipecat.processors.aggregators.gated import GatedAggregator
 from pipecat.processors.aggregators.sentence import SentenceAggregator
+from pipecat.processors.aggregators.json_sentence import JSONSentenceAggregator
 from pipecat.tests.utils import run_test
 
 
@@ -74,3 +75,47 @@ class TestGatedAggregator(unittest.IsolatedAsyncioTestCase):
             frames_to_send=frames_to_send,
             expected_down_frames=expected_down_frames,
         )
+
+
+class TestJSONSentenceAggregator(unittest.IsolatedAsyncioTestCase):
+    async def test_json_detection(self):
+        aggregator = JSONSentenceAggregator()
+
+        frames_to_send = [
+            TextFrame("{"),
+            TextFrame('"kind": "need",'),
+            TextFrame(' "id": "123"'),
+            TextFrame("}"),
+        ]
+
+        expected_down_frames = [TextFrame]
+
+        (received_down, _) = await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+
+        assert received_down[0].text == '{"kind": "need", "id": "123"}'
+
+    async def test_sentence_and_json(self):
+        aggregator = JSONSentenceAggregator()
+
+        frames_to_send = [
+            TextFrame("Hello world."),
+            TextFrame(" {"),
+            TextFrame('"kind": "need"'),
+            TextFrame(', "id": "1"'),
+            TextFrame("}"),
+        ]
+
+        expected_down_frames = [TextFrame, TextFrame]
+
+        (received_down, _) = await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+
+        assert received_down[0].text == "Hello world."
+        assert received_down[1].text == '{"kind": "need", "id": "1"}'


### PR DESCRIPTION
## Summary
- move JSONSentenceAggregator into screen navigation example
- update bot to import local aggregator
- add tests for JSON sentence detection

## Testing
- `pytest -k test_aggregators -q`
- `pytest examples/screen-navigation-webrtc/tests/test_json_sentence_aggregator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68544d109284832aa64eee80edee24e6