### PR TITLE
Handle system manifest in screen navigation example

### DIFF
--- a/examples/screen-navigation-webrtc/README.md
+++ b/examples/screen-navigation-webrtc/README.md
@@ -35,6 +35,10 @@ service (Deepgram in this demo) and simple patterns are matched to emit commands
 Use a custom WebRTC client to exchange SDP with the server's `/api/offer` endpoint.
 Once connected, audio will stream to the server and JSON messages containing
 transcripts and detected commands are sent back over the data channel.
+Before the connection is fully established, your client can send a JSON object
+with `{"role": "system", "content": "..."}` to provide an initial manifest for
+the LLM conversation. This message is appended to the conversation history
+before any user input is processed.
 
 ## Requirements
 

--- a/examples/screen-navigation-webrtc/server/bot.py
+++ b/examples/screen-navigation-webrtc/server/bot.py
@@ -116,6 +116,20 @@ async def run_bot(webrtc_connection):
         params=PipelineParams(allow_interruptions=False),
     )
 
+    system_manifest_received = False
+
+    @transport.event_handler("on_app_message")
+    async def on_app_message(transport, message):
+        nonlocal system_manifest_received
+        if (
+            isinstance(message, dict)
+            and message.get("role") == "system"
+            and not system_manifest_received
+        ):
+            logger.debug("Received system manifest from client")
+            context.add_message({"role": "system", "content": message.get("content", "")})
+            system_manifest_received = True
+
     @transcript.event_handler("on_transcript_update")
     async def on_transcript_update(processor, frame):
         for msg in frame.messages:


### PR DESCRIPTION
## Summary
- append system manifest from the client to the conversation in `screen-navigation-webrtc`
- document manifest behavior in example README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68547bcb0f9c832aaee87b5be701baef